### PR TITLE
Support for login credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ fwdl is a funkwhale albums downloader
 
 ## Build
 
+Mofify <username> and <password> with your Funkwhale credentials. Then:
+
 `go build`
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ fwdl is a funkwhale albums downloader
 
 ## Build
 
-Mofify <username> and <password> with your Funkwhale credentials. Then:
+Mofify \<username\> and \<password\> with your Funkwhale credentials. Then:
 
 `go build`
 

--- a/fwdl.go
+++ b/fwdl.go
@@ -70,7 +70,6 @@ func createAlbumDir(instanceUrl, id string) string {
 	var jsonMap map[string]any
 	json.Unmarshal(rawBody, &jsonMap)
 	dirPath := jsonMap["title"].(string)
-
 	err := os.Mkdir(dirPath, os.ModePerm)
 	check(err)
 
@@ -78,10 +77,12 @@ func createAlbumDir(instanceUrl, id string) string {
 }
 
 func getWithBody(url string) []byte {
-	res, err := http.Get(url)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	req.SetBasicAuth("<username>", "<password>")
+	res, err := client.Do(req)
 	check(err)
 	defer res.Body.Close()
-
 	rawBody, err := io.ReadAll(res.Body)
 	check(err)
 


### PR DESCRIPTION
I had trouble getting this to work because the GET request was returning "credentials were not provided" instead of the required JSON file.  The reason was that Funkwhale requires login credentials to access this data.

Not sure if this is a new development of funkwhale, or if I was running this script the wrong way, but with the changes here, it works fine for my Funkwhale instance running version 1.4.0 in Docker.